### PR TITLE
Fix deprecated embedded HAL GPIO types, clippy lints and update dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ license = "Apache-2.0"
 repository = "https://github.com/uwearzt/as5048a"
 
 [dependencies]
-embedded-hal = "0.2.2"
+embedded-hal = "0.2.6"
 
 # ------------------------------------------------------------------------------
 # build example raspberrypi.rs
-linux-embedded-hal = "0.2.2"
+linux-embedded-hal = "0.3.2"

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), std::io::Error> {
     ncs.set_direction(Direction::Out).unwrap();
     ncs.set_value(1).unwrap();
 
-    let mut as5048 = AS5048A::new(spi, ncs).unwrap();
+    let mut as5048 = AS5048A::new(spi, ncs);
 
     println!("AS5048A Example");
     loop {

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut spi = Spidev::open("/dev/spidev0.0").unwrap();
     let options = SpidevOptions::new()
         .max_speed_hz(1_000_000)
-        .mode(spidev::SPI_MODE_1)
+        .mode(spidev::SpiModeFlags::SPI_MODE_1)
         .build();
     spi.configure(&options).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,35 @@
 
 #![no_std]
 
-extern crate embedded_hal as hal;
+use core::fmt;
 
+use embedded_hal as hal;
 use hal::blocking::spi::Transfer;
-use hal::digital::OutputPin;
-use hal::spi::{Mode, Phase, Polarity};
+use hal::digital::v2::OutputPin;
+
+pub enum Error<SPI, CS>
+where
+    SPI: Transfer<u8>,
+    CS: OutputPin,
+{
+    Spi(SPI::Error),
+    ChipSelect(CS::Error),
+}
+
+impl<SPI, CS> fmt::Debug for Error<SPI, CS>
+where
+    SPI: Transfer<u8>,
+    <SPI as Transfer<u8>>::Error: fmt::Debug,
+    CS: OutputPin,
+    <CS as OutputPin>::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Spi(error) => write!(f, "Spi({:?})", error),
+            Error::ChipSelect(error) => write!(f, "ChipSelect({:?})", error),
+        }
+    }
+}
 
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
@@ -35,26 +59,24 @@ where
     SPI: Transfer<u8, Error = E>,
     CS: OutputPin,
 {
-    pub fn new(spi: SPI, cs: CS) -> Result<Self, E> {
-        let as5048 = AS5048A { spi: spi, cs: cs };
-
-        Ok(as5048)
+    pub fn new(spi: SPI, cs: CS) -> Self {
+        Self { spi, cs }
     }
 
-    pub fn diag_gain(&mut self) -> Result<(u8, u8), E> {
-        match self.read(Register::DiagAgc) {
-            Ok(arr) => Ok((arr[0] & 0x0f, arr[1])),
-            Err(e) => Err(e),
-        }
+    pub fn diag_gain(&mut self) -> Result<(u8, u8), Error<SPI, CS>> {
+        self.read(Register::DiagAgc)
+            .map(|arr| (arr[0] & 0x0f, arr[1]))
     }
-    pub fn magnitude(&mut self) -> Result<u16, E> {
+
+    pub fn magnitude(&mut self) -> Result<u16, Error<SPI, CS>> {
         self.read_u16(Register::Magnitude)
     }
-    pub fn angle(&mut self) -> Result<u16, E> {
+
+    pub fn angle(&mut self) -> Result<u16, Error<SPI, CS>> {
         self.read_u16(Register::Angle)
     }
 
-    fn read_u16(&mut self, reg: Register) -> Result<u16, E> {
+    fn read_u16(&mut self, reg: Register) -> Result<u16, Error<SPI, CS>> {
         match self.read(reg) {
             Ok(arr) => {
                 let y = u16::from_be_bytes(arr);
@@ -63,29 +85,30 @@ where
             Err(e) => Err(e),
         }
     }
-    fn read(&mut self, reg: Register) -> Result<[u8; 2], E> {
+
+    fn read(&mut self, reg: Register) -> Result<[u8; 2], Error<SPI, CS>> {
         // send cmd
         let mut cmd: u16 = 0b_0100_0000_0000_0000;
-        cmd = cmd | reg as u16;
+        cmd |= reg as u16;
         cmd = set_parity(cmd);
 
         let mut bytes = cmd.to_be_bytes();
 
-        self.cs.set_low();
-        self.spi.transfer(&mut bytes)?;
-        self.cs.set_high();
+        self.cs.set_low().map_err(Error::ChipSelect)?;
+        self.spi.transfer(&mut bytes).map_err(Error::Spi)?;
+        self.cs.set_high().map_err(Error::ChipSelect)?;
 
         // send nop to get result back
         let mut nop = [0x00, 0x00];
-        self.cs.set_low();
-        self.spi.transfer(&mut nop)?;
-        self.cs.set_high();
+        self.cs.set_low().map_err(Error::ChipSelect)?;
+        self.spi.transfer(&mut nop).map_err(Error::Spi)?;
+        self.cs.set_high().map_err(Error::ChipSelect)?;
 
-        return Ok(nop);
+        Ok(nop)
     }
 }
 
-fn set_parity(par: u16) -> u16 {
+const fn set_parity(par: u16) -> u16 {
     let mut x = par;
 
     x = (x & 0x00FF) ^ (x >> 8);


### PR DESCRIPTION
Hi :)

i stumbled upon this lib looking for good rotation encoders, comparing the `as5048a` and the `as5600`. I found there were a few embedded hal traits which have been deprecated, so I fixed that and a number of clippy warnings along the way.
The new hal traits for `GPIO` are fallible, meaning there is another error besides the `SPI` error. I decided to add a 2-variant enum there, to disambiguate between the two. To not add a crate, some manual work was necessary for `fmt::Debug` and so on. Let me know what you think :)