### PR TITLE
Impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ license = "Apache-2.0"
 repository = "https://github.com/uwearzt/as5048a"
 
 [dependencies]
-embedded-hal = "0.2.6"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
 # ------------------------------------------------------------------------------
 # build example raspberrypi.rs
-linux-embedded-hal = "0.3.2"
+linux-embedded-hal = {version="0.4.0", features = ["spi","gpio_sysfs"], default-features = false}

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------------------------
 
 use linux_embedded_hal::sysfs_gpio::Pin;
-use linux_embedded_hal::{self as hal, SpidevBus};
+use linux_embedded_hal::{self as hal, Delay};
 
 use as5048a::AS5048A;
 
@@ -30,7 +30,7 @@ fn main() -> Result<(), std::io::Error> {
     ncs.set_direction(Direction::Out).unwrap();
     ncs.set_value(1).unwrap();
 
-    let mut as5048 = AS5048A::new(spi);
+    let mut as5048: AS5048A<_, Delay, 0> = AS5048A::new(spi, None);
 
     println!("AS5048A Example");
     loop {

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -3,25 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // ------------------------------------------------------------------------------
 
-use linux_embedded_hal as hal;
+use linux_embedded_hal::sysfs_gpio::Pin;
+use linux_embedded_hal::{self as hal, SpidevBus};
 
 use as5048a::AS5048A;
 
 use crate::hal::spidev::{self, SpidevOptions};
 use crate::hal::sysfs_gpio::Direction;
-use crate::hal::{Pin, Spidev};
-
 use std::thread;
 use std::time::Duration;
+use linux_embedded_hal::SpidevDevice;
 
 fn main() -> Result<(), std::io::Error> {
-    let mut spi = Spidev::open("/dev/spidev0.0").unwrap();
+    let mut spi = SpidevDevice::open("/dev/spidev0.0").unwrap();
     let options = SpidevOptions::new()
         .max_speed_hz(1_000_000)
         .mode(spidev::SpiModeFlags::SPI_MODE_1)
         .build();
     spi.configure(&options).unwrap();
 
+    
     // CS pin on SparkFun Breakout
     let ncs = Pin::new(8);
     ncs.export().unwrap();
@@ -29,7 +30,7 @@ fn main() -> Result<(), std::io::Error> {
     ncs.set_direction(Direction::Out).unwrap();
     ncs.set_value(1).unwrap();
 
-    let mut as5048 = AS5048A::new(spi, ncs);
+    let mut as5048 = AS5048A::new(spi);
 
     println!("AS5048A Example");
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,31 +9,23 @@
 
 use core::fmt;
 
-use embedded_hal as hal;
-use hal::blocking::spi::Transfer;
-use hal::digital::v2::OutputPin;
+use embedded_hal::spi::SpiDevice;
 
 /// Error
-pub enum Error<SPI, CS>
+pub enum Error<SPI>
 where
-    SPI: Transfer<u8>,
-    CS: OutputPin,
+    SPI: SpiDevice<u8>,
 {
     Spi(SPI::Error),
-    ChipSelect(CS::Error),
 }
 
-impl<SPI, CS> fmt::Debug for Error<SPI, CS>
+impl<SPI> fmt::Debug for Error<SPI>
 where
-    SPI: Transfer<u8>,
-    <SPI as Transfer<u8>>::Error: fmt::Debug,
-    CS: OutputPin,
-    <CS as OutputPin>::Error: fmt::Debug,
+    SPI: SpiDevice<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Spi(error) => write!(f, "Spi({:?})", error),
-            Error::ChipSelect(error) => write!(f, "ChipSelect({:?})", error),
         }
     }
 }
@@ -51,35 +43,33 @@ enum Register {
 }
 
 /// AS5048A driver
-pub struct AS5048A<SPI, CS> {
+pub struct AS5048A<SPI: SpiDevice<u8>> {
     spi: SPI,
-    cs: CS,
 }
 
-impl<SPI, CS, E> AS5048A<SPI, CS>
+impl<SPI, E> AS5048A<SPI>
 where
-    SPI: Transfer<u8, Error = E>,
-    CS: OutputPin,
+    SPI: SpiDevice<u8, Error = E>,
 {
-    pub fn new(spi: SPI, cs: CS) -> Self {
-        Self { spi, cs }
+    pub fn new(spi: SPI) -> Self {
+        Self { spi }
     }
 
-    pub fn diag_gain(&mut self) -> Result<(u8, u8), Error<SPI, CS>> {
+    pub fn diag_gain(&mut self) -> Result<(u8, u8), Error<SPI>> {
         self.read(Register::DiagAgc)
             .map(|arr| (arr[0] & 0x0f, arr[1]))
     }
 
-    pub fn magnitude(&mut self) -> Result<u16, Error<SPI, CS>> {
+    pub fn magnitude(&mut self) -> Result<u16, Error<SPI>> {
         self.read_u16(Register::Magnitude)
     }
 
     /// Read the rotation angle as u16 (only 14 bits are significant)
-    pub fn angle(&mut self) -> Result<u16, Error<SPI, CS>> {
+    pub fn angle(&mut self) -> Result<u16, Error<SPI>> {
         self.read_u16(Register::Angle)
     }
 
-    fn read_u16(&mut self, reg: Register) -> Result<u16, Error<SPI, CS>> {
+    fn read_u16(&mut self, reg: Register) -> Result<u16, Error<SPI>> {
         match self.read(reg) {
             Ok(arr) => {
                 let y = u16::from_be_bytes(arr);
@@ -89,25 +79,21 @@ where
         }
     }
 
-    fn read(&mut self, reg: Register) -> Result<[u8; 2], Error<SPI, CS>> {
+    fn read(&mut self, reg: Register) -> Result<[u8; 2], Error<SPI>> {
         // send cmd
         let mut cmd: u16 = 0b_0100_0000_0000_0000;
         cmd |= reg as u16;
         cmd = set_parity(cmd);
 
-        let mut bytes = cmd.to_be_bytes();
-
-        self.cs.set_low().map_err(Error::ChipSelect)?;
-        self.spi.transfer(&mut bytes).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::ChipSelect)?;
+        let bytes = cmd.to_be_bytes();
+        let mut result = [0u8; 2];
+        self.spi.transfer(&mut result, &bytes).map_err(Error::Spi)?;
 
         // send nop to get result back
-        let mut nop = [0x00, 0x00];
-        self.cs.set_low().map_err(Error::ChipSelect)?;
-        self.spi.transfer(&mut nop).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::ChipSelect)?;
+        let nop = [0x00, 0x00];
+        self.spi.transfer(&mut result,&nop).map_err(Error::Spi)?;
 
-        Ok(nop)
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
Implemented support for embedded-hal-1

I now base the as5048a driver on the SpiDevice trait, so the CS management is removed from the driver.

I have no embedded-linux hardware, so I can not test it, but this does work fine on an esp32c3

Also I'm considering adding a feature flag for embedded-hal-async, please let me know if you are interested in PR's at all.